### PR TITLE
remove validates bank transfer transaction_reference_no

### DIFF
--- a/core/app/models/spree/payment.rb
+++ b/core/app/models/spree/payment.rb
@@ -22,7 +22,7 @@ module Spree
     has_attached_file :receipt_img, dependent: :destroy
     validates_attachment :receipt_img, :content_type => { :content_type => /\Aimage\/.*\Z/ }, :size => { :in => 0..2.megabytes }
 
-    validates :bank_name, :account_name, :account_no, :transaction_reference_no, :deposited_on, :presence => true, :if => :validate_bank_details
+    validates :bank_name, :account_name, :account_no, :deposited_on, :presence => true, :if => :validate_bank_details
     validates :bank_name, :length => { :minimum => 3, :too_short => "must have at least %{count} words"}, :if => :validate_bank_details
     validates :account_no, :length => { :minimum => 5 }, :numericality => true, :if => :validate_bank_details
 


### PR DESCRIPTION
change : 
1. core/app/models/spree/payment.rb
