### PR TITLE
max receipt_img size 7mb

### DIFF
--- a/core/app/models/spree/shipment.rb
+++ b/core/app/models/spree/shipment.rb
@@ -9,7 +9,7 @@ module Spree
 
     has_many :payments, as: :payable
     has_attached_file :receipt_img, dependent: :destroy
-    validates_attachment :receipt_img, :content_type => { :content_type => /\Aimage\/.*\Z/ }, :size => { :in => 0..500.kilobytes }
+    validates_attachment :receipt_img, :content_type => { :content_type => /\Aimage\/.*\Z/ }, :size => { :in => 0..7000.kilobytes }
   
     has_many :adjustments, as: :adjustable, dependent: :delete_all
     has_many :inventory_units, dependent: :delete_all, inverse_of: :shipment


### PR DESCRIPTION
core/app/models/spree/shipment.rb